### PR TITLE
add support for hungarian notation variable names

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
           "type": "boolean",
           "default": false,
           "description": "When enabled, JSDoc comments for functions and methods will include @description."
+        },
+        "docthis.enableHungarianNotationEvaluation": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, hungarian notation will be used as a type hint."
         }
       }
     }


### PR DESCRIPTION
This PR adds the ability to use type information from hungarian notation style variable names (as suggested in #49) for `@param` and `@type` JSDoc annotations. Evaluated starting characters (see `Documenter#_getHungarianNotationType`) are

- a = `{Array}`
- b = `{boolean}`
- f = `{function}`
- i = `{number}`
- s = `{string}`
- e/m/o = `{Object}`

Variable names are only evaluated if they match `/^[abefimos][A-Z]/`. Furthermore the functionality is only called if the configuration option `docthis.enableHungarianNotationEvaluation` is `true` (which is `false` by default).

---

*Disclaimer:* I really wanted to write tests for this PR. But all this functionality is hidden in private methods of `Documenter`. So I would have had to test it via calls to the public members, e.g. `Documenter#documentThis`. But then I would have had to mock a `vs.TextEditor` (or create a real one) etc. and this looked like overkill to me (given that there are no meaningful tests anywhere yet).