### PR TITLE
Added inferring of param type and return type from name if no type info is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Prints info about the node ancestry at a given caret position.
 [![Paypal Donations](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&amp;business=7YU9WH4ANAB4Q&amp;lc=US&amp;item_name=Document%20This&amp;item_number=vscode-docthis%20extension&amp;currency_code=USD&amp;bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted)
 
 ## Changes
+### 0.3.10
+- Adds option to infer param type & method return type from names if no type info is available. Controlled using the `docthis.inferTypesFromNames` option.
+
 ### 0.3.7
 - Upgraded TypeScript and VSCode internals.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "docthis",
   "displayName": "Document This",
   "description": "Automatically generates detailed JSDoc comments in TypeScript and JavaScript files.",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "publisher": "joelday",
   "icon": "images/icon.svg",
   "galleryBanner": {
@@ -94,6 +94,11 @@
           "type": "boolean",
           "default": false,
           "description": "When enabled, hungarian notation will be used as a type hint."
+        },
+        "docthis.inferTypesFromNames": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, will use names of params & methods as type hints."
         }
       }
     }


### PR DESCRIPTION
SublimeText has a handy feature where the type is inferred from the name. Would be awesome to get that added in!

https://github.com/spadgos/sublime-jsdocs/blob/master/jsdocs.py#L531