### PR TITLE
Support property declaration JSDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.5.0
+- Support documentation generation for class methods.
+
 ### 0.4.7
 - Protecting against error for /** auto documentation.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "docthis",
   "displayName": "Document This",
   "description": "Automatically generates detailed JSDoc comments in TypeScript and JavaScript files.",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "publisher": "joelday",
   "icon": "images/icon.png",
   "galleryBanner": {

--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -241,7 +241,8 @@ export class Documenter implements vs.Disposable {
         let targetNode = node.parent;
 
         if (node.parent.kind !== ts.SyntaxKind.PropertyAssignment &&
-            node.parent.kind !== ts.SyntaxKind.BinaryExpression) {
+            node.parent.kind !== ts.SyntaxKind.BinaryExpression &&
+            node.parent.kind !== ts.SyntaxKind.PropertyDeclaration) {
 
             targetNode = utils.findFirstParent(targetNode, [ts.SyntaxKind.VariableDeclarationList, ts.SyntaxKind.VariableDeclaration]);
             if (!targetNode) {


### PR DESCRIPTION
Nice plugin!  This change generates documentation for arrow functions that are class properties...
i.e.

```javascript
class Foo {
    bar = () => {
        console.log('hello world');
    };
}
```