### PR TITLE
Added spaces after author and date

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Demo](images/demo.gif)
 
 # Tags
-Supports JSDoc and Closure Compiler tags: @class, @description, @enum, @export, @function, @implements, @interface, @param, @private, @returns, @static, @template, @type and @memberOf.
+Supports JSDoc and Closure Compiler tags: @class, @description, @enum, @export, @function, @implements, @interface, @param, @private, @returns, @static, @template, @type, @memberOf and @date.
 
 # Commands
 ## Document This

--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -202,7 +202,7 @@ export class Documenter implements vs.Disposable {
     private _emitAuthor(sb: utils.SnippetStringBuilder) {
         if (vs.workspace.getConfiguration().get("docthis.includeAuthorTag", false)) {
             let author: string = vs.workspace.getConfiguration().get("docthis.authorName", "");
-            sb.append("@author" + author);
+            sb.append("@author " + author);
             sb.appendSnippetTabstop();
             sb.appendLine();
         }
@@ -210,7 +210,7 @@ export class Documenter implements vs.Disposable {
 
     private _emitDate(sb: utils.SnippetStringBuilder) {
         if (vs.workspace.getConfiguration().get("docthis.includeDateTag", false)) {
-            sb.append("@date" + utils.getCurrentDate());
+            sb.append("@date " + utils.getCurrentDate());
             sb.appendSnippetTabstop();
             sb.appendLine();
         }


### PR DESCRIPTION
/**
     * @description
     * @authormbaric
     * @date2018-06-03
     * @param {MouseEvent} e
     */

to

/**
     * @description
     * @author mbaric
     * @date 2018-06-03
     * @param {MouseEvent} e
     */