### PR TITLE
space for constructor text

### DIFF
--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -471,7 +471,7 @@ export class Documenter implements vs.Disposable {
     }
 
     private _emitConstructorDeclaration(sb: utils.SnippetStringBuilder, node: ts.ConstructorDeclaration) {
-        sb.appendSnippetPlaceholder(`Creates an instance of ${
+        sb.appendSnippetPlaceholder(` Creates an instance of ${
             (<ts.ClassDeclaration>node.parent).name.getText()
             }.`);
         sb.appendLine();


### PR DESCRIPTION
/**
     *Creates an instance
     * @author mbaric
     * @date 2018-06-08
     */

to 

/**
     * Creates an instance
     * @author mbaric
     * @date 2018-06-08
     */

As TSLint throws not aligned errors.