### PR TITLE
Enable docs for interface CallSignatures (Fixes #123)

### DIFF
--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -164,6 +164,7 @@ export class Documenter implements vs.Disposable {
             case ts.SyntaxKind.EnumMember:
                 sb.appendLine();
                 break;
+            case ts.SyntaxKind.CallSignature:
             case ts.SyntaxKind.FunctionDeclaration:
             case ts.SyntaxKind.MethodDeclaration:
             case ts.SyntaxKind.MethodSignature:

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -17,7 +17,8 @@ const supportedNodeKinds = [
     ts.SyntaxKind.PropertySignature,
     ts.SyntaxKind.Constructor,
     ts.SyntaxKind.FunctionExpression,
-    ts.SyntaxKind.VariableDeclaration];
+    ts.SyntaxKind.VariableDeclaration,
+    ts.SyntaxKind.CallSignature];
 
 export function emptyArray(arr: any[]) {
     while (arr.length > 0) {


### PR DESCRIPTION
Allows generating docs for call signatures of interfaces and types, e.g.

```ts
    interface Foo {
        /**
         * @description
         * @param {string} bar
         * @returns {*}
         * @memberof Foo
         */
        (bar: string): any;
    }
```

This fixes issue #123 