### PR TITLE
Docthis for variables. Inline Comments with just one line.

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
           "type": "boolean",
           "default": false,
           "description": "When enabled, will add the @date tag in YYYY-MM-DD format."
+        },
+        "docthis.inlineOneLiners": {
+          "type": "boolean",
+          "default": true,
+          "description": "When enabled, comments that only have one line, will be displayed in one line instead of three."
         }
       }
     }

--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -38,7 +38,11 @@ export class Documenter implements vs.Disposable {
 
         const position = ts.getPositionOfLineAndCharacter(sourceFile, caret.line, caret.character);
         const node = utils.findChildForPosition(sourceFile, position);
-        const documentNode = utils.nodeIsOfKind(node) ? node : utils.findFirstParent(node);
+        let documentNode = utils.nodeIsOfKind(node) ? node : utils.findFirstParent(node);
+        if (documentNode && documentNode.kind === ts.SyntaxKind.VariableDeclarationList) {
+            // extract VariableDeclaration from VariableDeclarationList
+            documentNode = (<ts.VariableDeclarationList> documentNode).declarations[0];
+        }
 
         if (!documentNode) {
             this._showFailureMessage(commandName, "at the current position");
@@ -225,7 +229,8 @@ export class Documenter implements vs.Disposable {
             }
         }
 
-        return;
+        sb.append(`@type {*}`);
+        return ts.getLineAndCharacterOfPosition(sourceFile, node.parent.getStart());
     }
 
     private _emitFunctionExpression(sb: utils.SnippetStringBuilder, node: ts.FunctionExpression | ts.ArrowFunction, sourceFile: ts.SourceFile) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -22,7 +22,9 @@ const supportedNodeKinds = [
     ts.SyntaxKind.Constructor,
     ts.SyntaxKind.FunctionExpression,
     ts.SyntaxKind.VariableDeclaration,
-    ts.SyntaxKind.CallSignature];
+    ts.SyntaxKind.CallSignature,
+    ts.SyntaxKind.VariableDeclarationList,
+];
 
 export function emptyArray(arr: any[]) {
     while (arr.length > 0) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -2,6 +2,10 @@ import * as path from "path";
 import * as ts from "typescript";
 import * as vs from "vscode";
 
+function inlineOneLiners() {
+    return vs.workspace.getConfiguration().get("docthis.inlineOneLiners", true);
+}
+
 const supportedNodeKinds = [
     ts.SyntaxKind.ClassDeclaration,
     ts.SyntaxKind.PropertyDeclaration,
@@ -233,9 +237,15 @@ export class SnippetStringBuilder {
     toCommentValue() {
         let sb = new StringBuilder();
 
+        const lines = this._snippet.value.split("\n");
+
+        const inline = lines.length === 1 && inlineOneLiners();
+
+        if (inline) {
+            sb.appendLine(`/** ${lines[0]} */`);
+        } else {
         sb.appendLine("/**");
 
-        const lines = this._snippet.value.split("\n");
         lines.forEach((line, i) => {
             if (line === "" && i === lines.length - 1) {
                 return;
@@ -252,6 +262,7 @@ export class SnippetStringBuilder {
         });
 
         sb.appendLine(" */");
+        }
 
         return new vs.SnippetString(sb.toString());
     }


### PR DESCRIPTION
Hi,

I made two changes which I'd like to add to vscode-docthis, because I think they would improve productivity.

### Commit: Added support for Identifier declaration.

I often define variables and assign them values later. In that case the type is unknown. With the changes I made, docthis can create comments for variables (Identifier declaration).
(it doesnt make sense to infer the type, because no comment is needed if TS is able to infer the type.)

before:
```javascript
let myVariable;
// type is implicitly any.
```
after:
```javascript
/**
 * @type {string}
 */
let myVariable;
// type is explicitely string
```

### Commit: Added configuration: inlineOneLiners

In my opinion, a three-line comment is too much for something as simple as a type comment on a variable. Therefore I added the option `inlineOneLiners` to inline three-line comments.

before:
```javascript
/**
 * @type {string}
 */
let myVariable;
```
after:
```javascript
/** @type {string} **/
let myVariable;
```

