### PR TITLE
Make optional the line jump after description free-type area

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
           "type": "boolean",
           "default": false,
           "description": "When enabled, will add the @date tag in YYYY-MM-DD format."
+        },
+		"docthis.includeExtraLineAfterDescription": {
+          "type": "boolean",
+          "default": true,
+          "description": "When enabled, will jump a line after description free-type area before showing other tags"
         }
       }
     }

--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -196,7 +196,9 @@ export class Documenter implements vs.Disposable {
             sb.appendLine();
 
             // Jump a line after description free-type area before showing other tags
-            sb.appendLine();
+			if (vs.workspace.getConfiguration().get("docthis.includeExtraLineAfterDescription", true)) {
+				sb.appendLine();
+			}
         }
     }
 


### PR DESCRIPTION
Some projects don't use the empty line between the description area and the @params area. This adds the option to the extension's settings.